### PR TITLE
Move autoclicker implementation to its own file

### DIFF
--- a/src/autoclicker.rs
+++ b/src/autoclicker.rs
@@ -1,0 +1,89 @@
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+
+use evdev::uinput::VirtualDevice;
+use evdev::{AttributeSet, KeyCode, KeyEvent};
+
+// Implement the autoclicker functionality using evdev
+#[derive(Clone)]
+pub struct Autoclicker {
+    device: Arc<Mutex<VirtualDevice>>,
+    running: Arc<Mutex<bool>>,
+}
+
+impl Autoclicker {
+    // Create a new Autoclicker instance.
+    // This will create a virtual mouse device "turbo-clicker-mouse" that can emit key events.
+    // Will fail if the device cannot be created.
+    pub fn new() -> Result<Self, Box<dyn std::error::Error>> {
+        let device = VirtualDevice::builder()?
+            .name("turbo-clicker-mouse")
+            .with_keys(&AttributeSet::from_iter([KeyCode::BTN_LEFT]))?
+            .build()?;
+
+        Ok(Autoclicker {
+            device: Arc::new(Mutex::new(device)),
+            running: Arc::new(Mutex::new(false)),
+        })
+    }
+
+    // Start the autoclicker with the given delay in milliseconds between clicks.
+    // If a start delay (in seconds) is provided, it will wait for it before starting.
+    // If a duration (in seconds) is provided, it will stop the autoclicker after that duration.
+    // Returns true if the autoclicker was started, false if it was already running.
+    pub fn autoclick(
+        &mut self,
+        delay_ms: u64,
+        start_delay: Option<u64>,
+        duration: Option<u64>,
+    ) -> bool {
+        let running = Arc::clone(&self.running);
+        {
+            let mut running = running.lock().expect("Autoclicker running lock poisoned");
+            if *running {
+                return false;
+            }
+            *running = true;
+        }
+
+        if let Some(start_delay) = start_delay {
+            println!("Waiting for {start_delay} s before starting autoclicker");
+            thread::sleep(Duration::from_secs(start_delay));
+        }
+
+        let device = Arc::clone(&self.device);
+
+        thread::spawn(move || {
+            println!("Autoclicker started with delay: {delay_ms} ms");
+            while *running.lock().expect("Autoclicker running lock poisoned") {
+                match device
+                    .lock()
+                    .expect("Autoclicker device lock poisoned")
+                    .emit(&[
+                        *KeyEvent::new(KeyCode::BTN_LEFT, 1),
+                        *KeyEvent::new(KeyCode::BTN_LEFT, 0),
+                    ]) {
+                    Ok(_) => {}
+                    Err(e) => {
+                        eprintln!("Failed to emit click event: {e}");
+                    }
+                };
+                thread::sleep(Duration::from_millis(delay_ms));
+            }
+            println!("Autoclicker stopped");
+        });
+
+        if let Some(duration) = duration {
+            let running = Arc::clone(&self.running);
+            thread::spawn(move || {
+                println!("Autoclicker will stop after {duration} s");
+                thread::sleep(Duration::from_secs(duration));
+                let mut running = running.lock().expect("Autoclicker running lock poisoned");
+                *running = false;
+            });
+        }
+
+        true
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,70 +2,35 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 use std::error::Error;
-use std::sync::{Arc, Mutex};
-use std::thread;
-use std::time::Duration;
 
-use evdev::uinput::VirtualDevice;
-use evdev::{AttributeSet, KeyCode, KeyEvent};
+mod autoclicker;
 
 slint::include_modules!();
 
 fn main() -> Result<(), Box<dyn Error>> {
+    let mut autoclicker = autoclicker::Autoclicker::new()?;
     let ui = AppWindow::new()?;
 
-    ui.on_start_auto_click(start_auto_clicker);
+    ui.on_start_auto_click(
+        move |delay: i32,
+              start_delay: i32,
+              duration: i32,
+              use_start_delay: bool,
+              use_duration: bool| {
+            let start_delay: Option<u64> = match use_start_delay {
+                true => Some(start_delay.try_into().unwrap()),
+                false => None,
+            };
+            let duration: Option<u64> = match use_duration {
+                true => Some(duration.try_into().unwrap()),
+                false => None,
+            };
+
+            autoclicker.autoclick(delay.try_into().unwrap(), start_delay, duration);
+        },
+    );
 
     ui.run()?;
 
     Ok(())
-}
-
-/// Starts an auto clicker in the background, simulating left mouse clicks with the given delay (ms).
-/// Returns a handle to stop the clicker via the returned `watch::Sender<bool>`.
-fn start_auto_clicker(delay_ms: i32, duration: i32, start_delay: i32) {
-    let stop = Arc::new(Mutex::new(false));
-    let stop_clone = Arc::clone(&stop);
-
-    let mut device = VirtualDevice::builder()
-        .expect("Failed to create virtual device")
-        .name("turbo-clicker-mouse")
-        .with_keys(&AttributeSet::from_iter([KeyCode::BTN_LEFT]))
-        .expect("Failed to add BTN_LEFT key")
-        .build()
-        .expect("Failed to build virtual device");
-
-    thread::spawn(move || {
-        let stop = Arc::clone(&stop_clone);
-        println!("Waiting for clicker to start");
-        thread::sleep(Duration::from_secs(start_delay.try_into().unwrap()));
-        println!("Starting loop");
-        loop {
-            if *stop.lock().unwrap() {
-                println!("Received stop signal");
-                break;
-            }
-            println!("Clicking...");
-
-            device
-                .emit(&[*KeyEvent::new(KeyCode::BTN_LEFT, 1)])
-                .expect("Failed to emit key press");
-            device
-                .emit(&[*KeyEvent::new(KeyCode::BTN_LEFT, 2)])
-                .expect("Failed to emit key release");
-
-            println!("Clicked");
-            thread::sleep(Duration::from_millis(delay_ms.try_into().unwrap()));
-        }
-    });
-
-    thread::spawn(move || {
-        println!("Waiting for duration to end");
-        thread::sleep(Duration::from_secs(
-            (duration + start_delay).try_into().unwrap(),
-        ));
-        println!("Sending stop signal");
-        let mut stop = stop.lock().unwrap();
-        *stop = true;
-    });
 }

--- a/ui/app-window.slint
+++ b/ui/app-window.slint
@@ -36,7 +36,7 @@ export component AppWindow inherits Window {
 
     in-out property <int> delay: 20;
 
-    callback start-auto-click(delay: int, duration: int, startDelay: int);
+    callback start-auto-click(delay: int, start_delay: int, duration: int, use_start_delay: bool, use_duration: bool);
 
     function setDelay(value: int) {
         if (value < 20) {
@@ -96,8 +96,7 @@ export component AppWindow inherits Window {
         Button {
             text: "Start Auto-click";
             clicked => {
-                root.start-auto-click(root.delay, autoclickDuration.value,
-                                    autoclickStartDelay.value);
+                root.start-auto-click(delay, autoclickStartDelay.value, autoclickDuration.value, autoclickStartDelay.enabled, autoclickDuration.enabled);
             }
         }
     }


### PR DESCRIPTION
Refactor the code to make autoclicker into a separate struct. This improves code readability and maintainability. Additionally it decuples the gui from the backend logic.