### PR TITLE
Add more verbose error message when failling to create autoclicker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 SHELL := bash
 
-# Build the binary in release mode
+# Build the binary for testing
+build:
+	cargo build
+
+# Build the binary in release mode and create release bundle
 release:
 	hack/build-release.sh
 
@@ -45,6 +49,7 @@ help:
 	@echo "Run 'make <target>' to execute a specific target."
 
 .PHONY: \
+	build \
 	release \
 	test \
 	coverprofile \

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,18 @@ mod autoclicker;
 slint::include_modules!();
 
 fn main() -> Result<(), Box<dyn Error>> {
-    let mut autoclicker = autoclicker::Autoclicker::new()?;
+    let mut autoclicker;
+    match autoclicker::Autoclicker::new() {
+        Ok(ac) => autoclicker = ac,
+        Err(e) => {
+            eprintln!("Error: {e}");
+            eprintln!(
+                "Please ensure this app has permissions to access /dev/uinput and that the uinput kernel module is loaded."
+            );
+            std::process::exit(1);
+        }
+    };
+
     let ui = AppWindow::new()?;
 
     ui.on_start_auto_click(


### PR DESCRIPTION
Describe the most likely failure point when failling to create the virtual
input device.
This gives the user guidance on how to fix the issue.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>