### PR TITLE
Install: Add udev rule for uinput permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ GUI based auto-clicker for Linux. It uses uinput and should thus work independen
   - [Installation](#installation)
     - [Download binary](#download-binary)
       - [Uninstalling](#uninstalling)
-    - [Flatpak](#flatpak)
     - [RPM](#rpm)
   - [Credits](#credits)
 
@@ -31,7 +30,7 @@ GUI based auto-clicker for Linux. It uses uinput and should thus work independen
 1. Download the [latest release](https://github.com/heathcliff26/turbo-clicker/releases/latest)
 2. Unpack the archive into your installation folder
 3. Switch to the installation folder
-4. Install the desktop file to list the app in the search by running:
+4. Install the desktop file and udev rules by running:
 ```bash
 ./install-desktop.sh -i
 ```
@@ -39,15 +38,11 @@ GUI based auto-clicker for Linux. It uses uinput and should thus work independen
 #### Uninstalling
 
 1. Switch to the installation folder
-2. Uninstall the desktop file by running:
+2. Uninstall by running:
 ```bash
 ./install-desktop.sh -u
 ```
-3. Delete the installation folder.
-
-### Flatpak
-
-The app can be installed from [flathub](https://github.com/flathub/io.github.heathcliff26.turbo-clicker)
+1. Delete the installation folder.
 
 ### RPM
 TODO?

--- a/packages/99-turbo-clicker-input.rules
+++ b/packages/99-turbo-clicker-input.rules
@@ -1,0 +1,2 @@
+# Turbo Clicker udev write access
+KERNEL=="uinput", SUBSYSTEM=="misc", TAG+="uaccess", OPTIONS+="static_node=uinput"

--- a/packages/install-desktop.sh
+++ b/packages/install-desktop.sh
@@ -4,6 +4,8 @@ base_dir="$(dirname "${BASH_SOURCE[0]}" | xargs realpath)"
 
 APP_ID="io.github.heathcliff26.turbo-clicker"
 DESKTOP_FILE_TARGET="${HOME}/.local/share/applications/${APP_ID}.desktop"
+UDEV_RULES_DIR="/usr/lib/udev/rules.d"
+UDEV_RULE="99-turbo-clicker-input.rules"
 
 help() {
     echo "Integrate Turbo Clicker with common desktop environments."
@@ -24,11 +26,19 @@ install() {
     else
         echo "The app will not show up in the menu until the session is restarted"
     fi
+
+    echo "Installing udev rules for Turbo Clicker"
+    sudo cp "${base_dir}/${UDEV_RULE}" "${UDEV_RULES_DIR}/${UDEV_RULE}"
+    sudo udevadm control --reload-rules
+    sudo udevadm trigger
+    echo "It might take a reboot for the udev rules to take effect."
 }
 
 uninstall() {
     rm "${DESKTOP_FILE_TARGET}"
     echo "Removed: ${DESKTOP_FILE_TARGET}"
+    sudo rm "${UDEV_RULES_DIR}/${UDEV_RULE}"
+    echo "Removed udev rules: ${UDEV_RULES_DIR}/${UDEV_RULE}"
 }
 
 while [[ "$#" -gt 0 ]]; do


### PR DESCRIPTION
Remove flathub installation method. With the needed permissions to access
`/dev/uinput`, running the app in a flatpak sandbox makes no sense.

Install a udev rule for accessing `/dev/uinput` as part of the installation
script.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>