### PR TITLE
Run app with pkexec

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,22 +28,22 @@ GUI based auto-clicker for Linux. It uses uinput and should thus work independen
 ### Download binary
 
 1. Download the [latest release](https://github.com/heathcliff26/turbo-clicker/releases/latest)
-2. Unpack the archive into your installation folder
-3. Switch to the installation folder
-4. Install the desktop file and udev rules by running:
+2. Unpack the archive
+3. Install the app for your user by running:
+   - You can install it globally by running the script with `sudo`
 ```bash
 ./install.sh -i
 ```
-5. You might need to reboot so that the changed permissions of `/dev/uinput` are reflected.
 
 #### Uninstalling
 
-1. Switch to the installation folder
+1. Switch to the folder with the installation script
 2. Uninstall by running:
+   - Run with `sudo` if you installed it globally
 ```bash
 ./install.sh -u
 ```
-3. Delete the installation folder.
+3. Delete the folder.
 
 ### Fedora Copr
 
@@ -56,7 +56,6 @@ sudo dnf copr enable heathcliff26/turbo-clicker
 ```bash
 sudo dnf install turbo-clicker
 ```
-3. You might need to reboot so that the changed permissions of `/dev/uinput` are reflected.
 
 ## Credits
 

--- a/packages/99-turbo-clicker-input.rules
+++ b/packages/99-turbo-clicker-input.rules
@@ -1,2 +1,0 @@
-# Turbo Clicker udev write access
-KERNEL=="uinput", SUBSYSTEM=="misc", TAG+="uaccess", OPTIONS+="static_node=uinput"

--- a/packages/io.github.heathcliff26.turbo-clicker.desktop
+++ b/packages/io.github.heathcliff26.turbo-clicker.desktop
@@ -7,5 +7,5 @@ Categories=Utility;
 Keywords=auto-clicker autoclicker clicker;
 
 Icon=io.github.heathcliff26.turbo-clicker
-Exec=turbo-clicker
+Exec=/usr/libexec/turbo-clicker-pkexec-wrapper.sh
 Terminal=false

--- a/packages/turbo-clicker-pkexec-wrapper.sh
+++ b/packages/turbo-clicker-pkexec-wrapper.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+pkexec env WAYLAND_DISPLAY="$XDG_RUNTIME_DIR/$WAYLAND_DISPLAY" XDG_RUNTIME_DIR="/run/user/0" /usr/bin/turbo-clicker

--- a/tools/turbo-clicker.spec
+++ b/tools/turbo-clicker.spec
@@ -15,6 +15,8 @@ License:        Apache-2.0
 URL:            https://github.com/heathcliff26/turbo-clicker
 Source:         %{url}/archive/refs/tags/v%{version}.tar.gz
 
+Requires: polkit
+
 BuildRequires: cargo >= 1.87
 
 %global _description %{expand:
@@ -33,18 +35,18 @@ cargo build --release --offline
 
 %install
 install -D -m 755 target/release/%{name} %{buildroot}/%{_bindir}/%{name}
+install -D -m 755 packages/%{name}-pkexec-wrapper.sh %{buildroot}/%{_libexecdir}/%{name}-pkexec-wrapper.sh
 install -D -m 644 packages/%{package_id}.desktop %{buildroot}/%{_datadir}/applications/%{package_id}.desktop
 install -D -m 644 packages/%{package_id}.svg %{buildroot}/%{_datadir}/icons/hicolor/scalable/apps/%{package_id}.svg
-install -D -m 644 packages/99-turbo-clicker-input.rules %{buildroot}/usr/lib/udev/rules.d/99-turbo-clicker-input.rules
 install -D -m 644 %{package_id}.metainfo.xml %{buildroot}/%{_datadir}/metainfo/%{package_id}.metainfo.xml
 
 %files
 %license LICENSE
 %doc README.md
 %{_bindir}/%{name}
+%{_libexecdir}/%{name}-pkexec-wrapper.sh
 %{_datadir}/applications/%{package_id}.desktop
 %{_datadir}/icons/hicolor/scalable/apps/%{package_id}.svg
-/usr/lib/udev/rules.d/99-turbo-clicker-input.rules
 %{_datadir}/metainfo/%{package_id}.metainfo.xml
 
 %changelog


### PR DESCRIPTION
Instead of changing the device permissions, run the app as root with pkexec.
This does mean that dark/light mode preference can't be read.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>