### PR TITLE
UI: Update app to use pages instead of popups and Menu

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -23,29 +23,33 @@ fn main() -> Result<(), Box<dyn Error>> {
         }
     };
 
-    let ui = AppWindow::new()?;
-    ui.set_version(VERSION.into());
+    let app = AppWindow::new()?;
+    app.global::<GlobalState>().set_version(VERSION.into());
 
-    ui.on_start_auto_click(
-        move |delay: i32,
-              start_delay: i32,
-              duration: i32,
-              use_start_delay: bool,
-              use_duration: bool| {
-            let start_delay: Option<u64> = match use_start_delay {
-                true => Some(start_delay.try_into().unwrap()),
+    app.global::<GlobalState>().on_start_auto_click({
+        let app = app.as_weak();
+        move || {
+            let app = app.unwrap();
+            let global_state = app.global::<GlobalState>();
+
+            let start_delay: Option<u64> = match global_state.get_use_start_delay() {
+                true => Some(global_state.get_start_delay().try_into().unwrap()),
                 false => None,
             };
-            let duration: Option<u64> = match use_duration {
-                true => Some(duration.try_into().unwrap()),
+            let duration: Option<u64> = match global_state.get_use_duration() {
+                true => Some(global_state.get_duration().try_into().unwrap()),
                 false => None,
             };
 
-            autoclicker.autoclick(delay.try_into().unwrap(), start_delay, duration);
-        },
-    );
+            autoclicker.autoclick(
+                global_state.get_delay().try_into().unwrap(),
+                start_delay,
+                duration,
+            );
+        }
+    });
 
-    ui.run()?;
+    app.run()?;
 
     Ok(())
 }

--- a/ui/app-window.slint
+++ b/ui/app-window.slint
@@ -1,158 +1,23 @@
 import { Button, VerticalBox, HorizontalBox, SpinBox, Slider, CheckBox, Palette, AboutSlint } from "std-widgets.slint";
+import { GlobalState } from "global_state.slint";
+import { MainPage, AboutPage } from "pages/pages.slint";
+import { NavBar } from "nav-bar.slint";
 
-component OptionalIntInput inherits Rectangle {
-    in-out property <int> value: 0;
-    in-out property <bool> enabled: true;
-    in-out property <string> label: "";
-    in-out property <int> minimum: 0;
-    in-out property <int> maximum: 1000;
-    in-out property <int> step: 1;
-
-    HorizontalBox {
-        CheckBox {
-            checked: root.enabled;
-            text: root.label;
-            toggled => {
-                root.enabled = self.checked;
-            }
-        }
-
-        SpinBox {
-            minimum: root.minimum;
-            maximum: root.maximum;
-            step-size: root.step;
-            value: root.value;
-            enabled: root.enabled;
-            edited(value) => {
-                root.value = value;
-            }
-        }
-    }
-}
+export { GlobalState }
 
 export component AppWindow inherits Window {
     title: "Turbo Clicker";
     icon: @image-url("../packages/io.github.heathcliff26.turbo-clicker.svg");
     default-font-size: 18px;
+    preferred-height: 400px;
+    preferred-width: 500px;
 
-    in-out property <int> delay: 20;
-    in-out property <string> version: "-";
-
-    callback start-auto-click(delay: int, start_delay: int, duration: int, use_start_delay: bool, use_duration: bool);
-
-    function setDelay(value: int) {
-        if (value < 20) {
-            delay = 20;
-        } else if (value > 1000) {
-            root.delay = 1000;
-        } else {
-            delay = Math.floor(value);
-        }
-    }
-
-    MenuBar {
-        Menu {
-            title: "☰";
-            MenuItem {
-                title: "About";
-                activated => {
-                    aboutPopup.show();
-                }
-            }
-        }
-    }
-
-    aboutPopup := PopupWindow {
-        close-policy: close-on-click-outside;
-        x: (parent.width - self.width) / 2;
-        y: (parent.height - self.height) / 2;
-        width: 200px;
-        height: 220px;
-
-        Rectangle {
-            width: 100%;
-            height: 100%;
-            background: Palette.alternate-background;
-
-            VerticalBox {
-                Text {
-                    text: "Turbo Clicker";
-                    horizontal-alignment: center;
-                }
-
-                Text {
-                    text: "Version: v" + root.version;
-                    horizontal-alignment: center;
-                }
-
-                HorizontalBox {
-                    alignment: center;
-                    AboutSlint {
-                        width: 100px;
-                        height: 100px;
-                    }
-                }
-
-                Button {
-                    text: "Close";
-                    clicked => {
-                        aboutPopup.close();
-                    }
-                }
-            }
-        }
-    }
-
-    VerticalBox {
-        HorizontalBox {
-            delayLabel := Text {
-                text: "Delay between clicks (ms):";
-                vertical-alignment: center;
-            }
-
-            delayInput := SpinBox {
-                minimum: 20;
-                maximum: 1000;
-                step-size: 10;
-                value: root.delay;
-                edited(value) => {
-                    setDelay(value);
-                    delaySlider.value = root.delay;
-                }
-            }
+    VerticalLayout {
+        nav-bar := NavBar {
+            model: ["App", "About"];
         }
 
-        delaySlider := Slider {
-            minimum: 20;
-            maximum: 1000;
-            step: 10;
-            value: root.delay;
-
-            changed(value) => {
-                setDelay(value);
-                delayInput.value = root.delay;
-            }
-        }
-
-        autoclickDuration := OptionalIntInput {
-            label: "Auto-click Duration (s): ";
-            value: 1;
-            minimum: 1;
-            maximum: 60;
-        }
-
-        autoclickStartDelay := OptionalIntInput {
-            label: "Auto-click start delay (s): ";
-            value: 1;
-            minimum: 1;
-            maximum: 60;
-        }
-
-        Button {
-            text: "Start Auto-click";
-            clicked => {
-                root.start-auto-click(delay, autoclickStartDelay.value, autoclickDuration.value, autoclickStartDelay.enabled, autoclickDuration.enabled);
-            }
-        }
+        if(nav-bar.current-item == 0): MainPage { }
+        if(nav-bar.current-item == 1): AboutPage { }
     }
 }

--- a/ui/global_state.slint
+++ b/ui/global_state.slint
@@ -1,0 +1,25 @@
+export global GlobalState {
+    // The delay between clicks in milliseconds.
+    in-out property <int> delay: 20;
+    // The delay in seconds before starting the auto-click.
+    in-out property <int> start-delay: 1;
+    in-out property <bool> use-start-delay: true;
+    // The time to wait in seconds before stopping the auto-click.
+    in-out property <int> duration: 1;
+    in-out property <bool> use-duration: true;
+
+    // Application version. Needs to be populated from backend.
+    in-out property <string> version: "-";
+
+    callback start-auto-click();
+
+    public function setDelay(value: int) {
+        if (value < 20) {
+            delay = 20;
+        } else if (value > 1000) {
+            delay = 1000;
+        } else {
+            delay = Math.floor(value);
+        }
+    }
+}

--- a/ui/nav-bar.slint
+++ b/ui/nav-bar.slint
@@ -1,0 +1,84 @@
+import { HorizontalBox, VerticalBox, Palette } from "std-widgets.slint";
+
+component NavBarItem inherits Rectangle {
+    in property <int> tab-index;
+    in property <bool> selected;
+    in property <bool> has-focus;
+    in-out property <string> text <=> label.text;
+
+    callback clicked <=> touch.clicked;
+
+    min-height: l.preferred-height;
+    accessible-role: tab;
+    accessible-label: root.text;
+    accessible-item-index: root.tab-index;
+    accessible-item-selectable: true;
+    accessible-item-selected: root.selected;
+    accessible-action-default => {
+        self.clicked();
+    }
+
+    states [
+        pressed when touch.pressed: {
+            state.opacity: 0.8;
+        }
+        hover when touch.has-hover: {
+            state.opacity: 0.6;
+        }
+        selected when root.selected: {
+            state.opacity: 1;
+        }
+        focused when root.has-focus: {
+            state.opacity: 0.8;
+        }
+    ]
+
+    state := Rectangle {
+        opacity: 0;
+        background: Palette.background;
+
+        animate opacity { duration: 150ms; }
+    }
+
+    l := HorizontalBox {
+        y: (parent.height - self.height) / 2;
+        spacing: 0px;
+        alignment: center;
+
+        label := Text {
+            vertical-alignment: center;
+            accessible-role: none;
+        }
+    }
+
+    touch := TouchArea {
+        width: 100%;
+        height: 100%;
+    }
+}
+
+export component NavBar inherits Rectangle {
+    in property <[string]> model: [];
+    out property <int> current-item: 0;
+
+    height: 50px;
+
+    Rectangle {
+        background: Palette.background.darker(0.2);
+    }
+
+    HorizontalBox {
+        padding-top: 0px;
+        padding-bottom: 0px;
+
+        for item[index] in root.model: NavBarItem {
+            clicked => {
+                root.current-item = index;
+            }
+
+            tab-index: index;
+            text: item;
+            selected: index == root.current-item;
+        }
+    }
+}

--- a/ui/pages/about_page.slint
+++ b/ui/pages/about_page.slint
@@ -1,0 +1,29 @@
+import { HorizontalBox, AboutSlint } from "std-widgets.slint";
+import { Page } from "page.slint";
+import { GlobalState } from "../global_state.slint";
+
+export component AboutPage inherits Page {
+    title: "About";
+    padding-top: 50px;
+
+    Text {
+        text: "Turbo Clicker";
+        horizontal-alignment: center;
+    }
+
+    Text {
+        text: "Version: v" + GlobalState.version;
+        horizontal-alignment: center;
+    }
+
+    // Spacer
+    Rectangle { }
+
+    HorizontalBox {
+        alignment: center;
+        AboutSlint {
+            width: 100px;
+            height: 100px;
+        }
+    }
+}

--- a/ui/pages/main_page.slint
+++ b/ui/pages/main_page.slint
@@ -1,0 +1,83 @@
+import { Button,CheckBox,HorizontalBox, SpinBox, Slider } from "std-widgets.slint";
+import { Page } from "page.slint";
+import { GlobalState } from "../global_state.slint";
+
+component OptionalIntInput inherits Rectangle {
+    in-out property <int> value <=> input.value;
+    in-out property <bool> enabled <=> selected.checked;
+    in-out property <string> label <=> selected.text;
+    in-out property <int> minimum: 1;
+    in-out property <int> maximum: 1000;
+    in-out property <int> step: 1;
+
+    HorizontalBox {
+        selected := CheckBox { }
+
+        input := SpinBox {
+            minimum <=> root.minimum;
+            maximum <=> root.maximum;
+            step-size <=> root.step;
+            enabled <=> root.enabled;
+        }
+    }
+}
+
+export component MainPage inherits Page {
+    title: "App";
+
+    HorizontalBox {
+        Text {
+            text: "Delay between clicks (ms):";
+            vertical-alignment: center;
+        }
+
+        delayInput := SpinBox {
+            minimum: 20;
+            maximum: 1000;
+            step-size: 10;
+            value: GlobalState.delay;
+            edited(value) => {
+                GlobalState.setDelay(value);
+                delaySlider.value = GlobalState.delay;
+            }
+        }
+    }
+
+    delaySlider := Slider {
+        minimum: delayInput.minimum;
+        maximum: delayInput.maximum;
+        step: delayInput.step-size;
+        value: GlobalState.delay;
+
+        changed(value) => {
+            GlobalState.setDelay(value);
+            delayInput.value = GlobalState.delay;
+        }
+    }
+
+    OptionalIntInput {
+        label: "Auto-click Duration (s): ";
+        value <=> GlobalState.duration;
+        enabled <=> GlobalState.use-duration;
+        minimum: 1;
+        maximum: 60;
+    }
+
+    OptionalIntInput {
+        label: "Auto-click start delay (s): ";
+        value <=> GlobalState.start-delay;
+        enabled <=> GlobalState.use-start-delay;
+        minimum: 1;
+        maximum: 60;
+    }
+
+    // Spacer
+    Rectangle { }
+
+    Button {
+        text: "Start Auto-click";
+        clicked => {
+            GlobalState.start-auto-click();
+        }
+    }
+}

--- a/ui/pages/page.slint
+++ b/ui/pages/page.slint
@@ -1,0 +1,10 @@
+import { VerticalBox } from "std-widgets.slint";
+
+export component Page inherits VerticalBox {
+    in property <string> title: "title";
+
+    accessible-role: tab-panel;
+    accessible-label: root.title;
+
+    @children
+}

--- a/ui/pages/pages.slint
+++ b/ui/pages/pages.slint
@@ -1,0 +1,2 @@
+export { MainPage } from "main_page.slint";
+export { AboutPage } from "about_page.slint";


### PR DESCRIPTION
Improve the app look by using a navigation bar and pages.
Split the UI into multiple files for better maintainability.
Use a global state to communicate with the rust backend.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>