### PR TITLE
Fix missing icon in dash

### DIFF
--- a/packages/io.github.heathcliff26.turbo-clicker.desktop
+++ b/packages/io.github.heathcliff26.turbo-clicker.desktop
@@ -4,7 +4,7 @@ Type=Application
 Name=Turbo Clicker
 Comment=GUI based auto-clicker for Linux
 Categories=Utility;
-Keywords=auto-clicker autoclicker clicker;
+Keywords=auto-clicker autoclicker clicker mouse;
 
 Icon=io.github.heathcliff26.turbo-clicker
 Exec=/usr/libexec/turbo-clicker-pkexec-wrapper.sh

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod autoclicker;
 mod state;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
+const APP_ID: &str = concat!("io.github.heathcliff26.", env!("CARGO_PKG_NAME"));
 
 slint::include_modules!();
 
@@ -27,6 +28,8 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     let app = AppWindow::new()?;
     app.global::<GlobalState>().set_version(VERSION.into());
+
+    slint::set_xdg_app_id(APP_ID).expect("Failed to set XDG app ID");
 
     let state = match State::from_file() {
         Ok(state) => state,


### PR DESCRIPTION
Set XDG App id to ensure the icon get's shown in the dash.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>