### PR TITLE
UI: Add settings page with option to enabled dark mode

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -62,6 +62,17 @@ fn main() -> Result<(), Box<dyn Error>> {
         }
     });
 
+    app.global::<GlobalState>().on_settings_changed({
+        let app = app.as_weak();
+        move || {
+            let app = app.unwrap();
+            let state = State::from_app(&app);
+            if let Err(e) = state.save_to_file() {
+                eprintln!("Failed to save settings: {e}");
+            }
+        }
+    });
+
     app.run()?;
 
     let state = State::from_app(&app);

--- a/src/state.rs
+++ b/src/state.rs
@@ -27,6 +27,7 @@ pub struct State {
     pub duration: u64,
     pub use_start_delay: bool,
     pub use_duration: bool,
+    pub dark_mode: bool,
 }
 
 impl State {
@@ -40,6 +41,7 @@ impl State {
             duration: global_state.get_duration().try_into().unwrap(),
             use_start_delay: global_state.get_use_start_delay(),
             use_duration: global_state.get_use_duration(),
+            dark_mode: global_state.get_dark_mode(),
         }
     }
 
@@ -68,6 +70,7 @@ impl State {
         global_state.set_duration(self.duration as i32);
         global_state.set_use_start_delay(self.use_start_delay);
         global_state.set_use_duration(self.use_duration);
+        global_state.set_dark_mode(self.dark_mode);
     }
 
     /// Save the state to user specific state file.

--- a/src/state/test.rs
+++ b/src/state/test.rs
@@ -9,6 +9,7 @@ fn state_from_app() {
         duration: 10,
         use_start_delay: false,
         use_duration: true,
+        dark_mode: true,
     };
 
     i_slint_backend_testing::init_no_event_loop();
@@ -19,6 +20,7 @@ fn state_from_app() {
     global_state.set_duration(expected_state.duration as i32);
     global_state.set_use_start_delay(expected_state.use_start_delay);
     global_state.set_use_duration(expected_state.use_duration);
+    global_state.set_dark_mode(expected_state.dark_mode);
 
     assert_eq!(
         expected_state,
@@ -35,6 +37,7 @@ fn state_update_app() {
         duration: 15,
         use_start_delay: true,
         use_duration: false,
+        dark_mode: false,
     };
 
     i_slint_backend_testing::init_no_event_loop();
@@ -66,6 +69,11 @@ fn state_update_app() {
         state.use_duration,
         global_state.get_use_duration(),
         "GlobalState use_duration should match State use_duration"
+    );
+    assert_eq!(
+        state.dark_mode,
+        global_state.get_dark_mode(),
+        "GlobalState dark_mode should match State dark_mode"
     );
 }
 
@@ -103,6 +111,7 @@ fn state_from_file() {
         duration: 1,
         use_start_delay: true,
         use_duration: true,
+        dark_mode: false,
     };
 
     assert_eq!(
@@ -124,6 +133,7 @@ fn state_save_to_file() {
         duration: 25,
         use_start_delay: true,
         use_duration: true,
+        dark_mode: true,
     };
 
     let user = "save_to_file_test_user";

--- a/testdata/state_from_file_test_user.json
+++ b/testdata/state_from_file_test_user.json
@@ -1,1 +1,1 @@
-{"delay":500,"start_delay":60,"duration":1,"use_start_delay":true,"use_duration":true}
+{"delay":500,"start_delay":60,"duration":1,"use_start_delay":true,"use_duration":true,"dark_mode":false}

--- a/ui/app-window.slint
+++ b/ui/app-window.slint
@@ -1,5 +1,5 @@
 import { GlobalState } from "global_state.slint";
-import { MainPage, AboutPage } from "pages/pages.slint";
+import { MainPage, AboutPage, SettingsPage } from "pages/pages.slint";
 import { NavBar } from "nav-bar.slint";
 
 export { GlobalState }
@@ -11,12 +11,17 @@ export component AppWindow inherits Window {
     preferred-height: 400px;
     preferred-width: 500px;
 
+    init => {
+        GlobalState.setColorScheme();
+    }
+
     VerticalLayout {
         nav-bar := NavBar {
-            model: ["App", "About"];
+            model: ["App", "Settings", "About"];
         }
 
         if(nav-bar.current-item == 0): MainPage { }
-        if(nav-bar.current-item == 1): AboutPage { }
+        if(nav-bar.current-item == 1): SettingsPage { }
+        if(nav-bar.current-item == 2): AboutPage { }
     }
 }

--- a/ui/global_state.slint
+++ b/ui/global_state.slint
@@ -1,3 +1,5 @@
+import { Palette } from "std-widgets.slint";
+
 export global GlobalState {
     // The delay between clicks in milliseconds.
     in-out property <int> delay: 20;
@@ -8,10 +10,13 @@ export global GlobalState {
     in-out property <int> duration: 1;
     in-out property <bool> use-duration: true;
 
+    in-out property <bool> dark-mode: true;
+
     // Application version. Needs to be populated from backend.
     in-out property <string> version: "-";
 
     callback start-auto-click();
+    callback settings-changed();
 
     public function setDelay(value: int) {
         if (value < 20) {
@@ -21,5 +26,14 @@ export global GlobalState {
         } else {
             delay = Math.floor(value);
         }
+    }
+
+    public function setColorScheme() {
+        Palette.color-scheme = dark-mode ? ColorScheme.dark : ColorScheme.light;
+    }
+
+    changed dark-mode => {
+        setColorScheme();
+        settings-changed();
     }
 }

--- a/ui/pages/pages.slint
+++ b/ui/pages/pages.slint
@@ -1,2 +1,3 @@
 export { MainPage } from "main_page.slint";
+export { SettingsPage } from "settings_page.slint";
 export { AboutPage } from "about_page.slint";

--- a/ui/pages/settings_page.slint
+++ b/ui/pages/settings_page.slint
@@ -1,0 +1,14 @@
+import { Page } from "page.slint";
+import { GlobalState } from "../global_state.slint";
+import { Switch } from "std-widgets.slint";
+
+export component SettingsPage inherits Page {
+    title: "Settings";
+    padding: 10px;
+    alignment: start;
+
+    Switch {
+        text: "Dark Mode";
+        checked <=> GlobalState.dark-mode;
+    }
+}


### PR DESCRIPTION
The user preference can't be fetched from the system, due to running with
pkexec. To allow user to change the mode, add a settings page.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>