### PR TITLE
RPM: Drop unneeded cargo vendor

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,6 +4,7 @@
 rustflags = [
     "-C", "link-arg=/STACK:8000000"
 ]
+
 [target.aarch64-pc-windows-msvc]
 # Increase default stack size to avoid running out of stack
 # space in debug builds. The size matches Linux's default.

--- a/tools/turbo-clicker.spec
+++ b/tools/turbo-clicker.spec
@@ -27,11 +27,9 @@ independently of wayland or x11.}
 
 %prep
 %autosetup -n turbo-clicker-%{version} -p1
-# Need network for this part
-cargo vendor vendor
 
 %build
-cargo build --release --offline
+cargo build --release
 
 %install
 install -D -m 755 target/release/%{name} %{buildroot}/%{_bindir}/%{name}


### PR DESCRIPTION
The spec needs to be build online anyway. Drop unneeded cargo vendor.