### PR TITLE
autoclicker: Do not actually move mouse

### DIFF
--- a/src/autoclicker.rs
+++ b/src/autoclicker.rs
@@ -29,7 +29,7 @@ impl Autoclicker {
         let mut enigo = Enigo::new(&Settings::default())?;
 
         // Move the mouse slightly to ensure the permission prompt is triggered.
-        enigo.move_mouse(1, 1, Coordinate::Rel)?;
+        enigo.move_mouse(0, 0, Coordinate::Rel)?;
 
         Ok(Autoclicker {
             enigo: Arc::new(Mutex::new(enigo)),


### PR DESCRIPTION
Calling mouse move with 0,0 instead of 1,1 works just as well.
This ensures the user is asked for permission without actually moving the
mouse at all.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>