### PR TITLE
CI: Add make command for installing dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,6 @@ jobs:
       contents: read
     with:
       cmd: "make doc"
-      additional-packages: "libwayland-dev libfontconfig-dev qt6-base-dev qt6-wayland-dev libxkbcommon-dev"
 
   lint:
     uses: heathcliff26/ci/.github/workflows/run-script.yaml@main
@@ -45,7 +44,6 @@ jobs:
       contents: read
     with:
       cmd: "make lint"
-      additional-packages: "libwayland-dev libfontconfig-dev qt6-base-dev qt6-wayland-dev libxkbcommon-dev"
 
   test:
     uses: heathcliff26/ci/.github/workflows/run-script.yaml@main
@@ -53,7 +51,7 @@ jobs:
       contents: read
     with:
       cmd: "xvfb-run -a make test"
-      additional-packages: "libwayland-dev libfontconfig-dev qt6-base-dev qt6-wayland-dev libxkbcommon-dev xvfb xsel"
+      additional-packages: "xvfb xsel"
 
   validate:
     uses: heathcliff26/ci/.github/workflows/run-script.yaml@main
@@ -82,4 +80,3 @@ jobs:
       artifact: "dist/turbo-clicker_linux-${{ matrix.arch }}.tar.gz"
       artifact-name: "turbo-clicker-${{ matrix.arch }}"
       architecture: "${{ matrix.arch }}"
-      additional-packages: "libwayland-dev libfontconfig-dev qt6-base-dev qt6-wayland-dev libxkbcommon-dev"

--- a/.github/workflows/coverprofiles.yaml
+++ b/.github/workflows/coverprofiles.yaml
@@ -24,4 +24,4 @@ jobs:
     with:
       coverprofile: "target/coverage/lcov.info"
       script: "xvfb-run -a make coverprofile"
-      additional-packages: "libwayland-dev libfontconfig-dev qt6-base-dev qt6-wayland-dev libxkbcommon-dev  xvfb xsel"
+      additional-packages: "xvfb xsel"

--- a/Makefile
+++ b/Makefile
@@ -1,27 +1,27 @@
 SHELL := bash
 
 # Build the binary for testing
-build:
+build: install-deps
 	cargo build
 
 # Build the binary in release mode and create release bundle
-release:
+release: install-deps
 	hack/build-release.sh
 
 # Run cargo test
-test:
+test: install-deps
 	cargo test
 
 # Generate coverage profile
-coverprofile:
+coverprofile: install-deps
 	hack/coverprofile.sh
 
 # Run linter (clippy)
-lint:
+lint: install-deps
 	cargo clippy -- --deny warnings
 
 # Build the docs, fail on warnings
-doc:
+doc: install-deps
 	RUSTDOCFLAGS='--deny warnings' cargo doc --no-deps
 
 # Format the code
@@ -35,6 +35,10 @@ validate:
 # Validate the appstream metainfo file
 validate-metainfo:
 	appstreamcli validate io.github.heathcliff26.turbo-clicker.metainfo.xml
+
+# Install all dependencies needed for development
+install-deps:
+	hack/install-deps.sh
 
 # Clean up generated files
 clean:
@@ -58,6 +62,7 @@ help:
 	fmt \
 	validate \
 	validate-metainfo \
+	install-deps \
 	clean \
 	help \
 	$(NULL)

--- a/hack/install-deps.sh
+++ b/hack/install-deps.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+set -e
+
+install_apt () {
+    packages="qt6-base-dev qt6-wayland-dev libfontconfig-dev libxkbcommon-dev"
+    run_install=no
+
+    for package in ${packages}; do
+        if ! dpkg -l "${package}" > /dev/null 2>&1; then
+            run_install=yes
+            break
+        fi
+    done
+
+    if [ "$run_install" = "yes" ]; then
+        echo "Installing missing dependencies..."
+        sudo apt-get update
+        #shellcheck disable=SC2086
+        sudo apt-get install -y ${packages}
+    else
+        echo "All dependencies are already installed."
+    fi
+}
+
+install_dnf () {
+    packages="qt6-qtbase-devel qt6-qtwayland-devel fontconfig-devel"
+    run_install=no
+
+    for package in ${packages}; do
+        if ! rpm -q "${package}" > /dev/null 2>&1; then
+            run_install=yes
+            break
+        fi
+    done
+
+    if [ "$run_install" = "yes" ]; then
+        echo "Installing missing dependencies..."
+        #shellcheck disable=SC2086
+        sudo dnf install -y ${packages}
+    else
+        echo "All dependencies are already installed."
+    fi
+}
+
+source /etc/os-release
+
+case "${ID}" in
+    "ubuntu"|"debian")
+        install_apt
+        ;;
+    "fedora")
+        install_dnf
+        ;;
+    *)
+        echo "Unknown OS ${ID}, you need to manage dependencies manually"
+esac


### PR DESCRIPTION
Instead of redefining common dependencies over and over, centralize their installation in a single script. Make the script run before other steps to ensure all dependencies are installed.