### PR TITLE
CI: Fix permissions for coverprofile workflow

### DIFF
--- a/.github/workflows/build-builder.yaml
+++ b/.github/workflows/build-builder.yaml
@@ -1,5 +1,5 @@
 ---
-name: Build Builder Image
+name: Builder Image
 
 on:
   workflow_dispatch:

--- a/.github/workflows/coverprofiles.yaml
+++ b/.github/workflows/coverprofiles.yaml
@@ -1,5 +1,5 @@
 ---
-name: "Generate test cover report"
+name: "Coverprofiles"
 
 on:
   workflow_dispatch:
@@ -20,7 +20,8 @@ jobs:
   generate-reports:
     uses: heathcliff26/ci/.github/workflows/testcover-report.yaml@main
     secrets: inherit
-    permissions: {}
+    permissions:
+      contents: read
     with:
       coverprofile: "target/coverage/lcov.info"
       script: "xvfb-run -a make coverprofile"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 [![Coverage Status](https://coveralls.io/repos/github/heathcliff26/turbo-clicker/badge.svg)](https://coveralls.io/github/heathcliff26/turbo-clicker)
 [![Editorconfig Check](https://github.com/heathcliff26/turbo-clicker/actions/workflows/editorconfig-check.yaml/badge.svg?event=push)](https://github.com/heathcliff26/turbo-clicker/actions/workflows/editorconfig-check.yaml)
 [![Renovate](https://github.com/heathcliff26/turbo-clicker/actions/workflows/renovate.yaml/badge.svg)](https://github.com/heathcliff26/turbo-clicker/actions/workflows/renovate.yaml)
+[![Coverprofiles](https://github.com/heathcliff26/turbo-clicker/actions/workflows/coverprofiles.yaml/badge.svg)](https://github.com/heathcliff26/turbo-clicker/actions/workflows/coverprofiles.yaml)
+[![Builder Image](https://github.com/heathcliff26/turbo-clicker/actions/workflows/build-builder.yaml/badge.svg)](https://github.com/heathcliff26/turbo-clicker/actions/workflows/build-builder.yaml)
 
 # Turbo Clicker
 


### PR DESCRIPTION
In order to run it without app token on PRs, read permissions are needed. 
Additionally add badges to readme.