### PR TITLE
Build builder image for x86_64 only

### DIFF
--- a/.github/workflows/build-builder.yaml
+++ b/.github/workflows/build-builder.yaml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build:
-    uses: heathcliff26/ci/.github/workflows/build-container.yaml@main
+    uses: heathcliff26/ci/.github/workflows/build-amd64-container.yaml@main
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,11 +62,6 @@ jobs:
 
   build-binary:
     uses: heathcliff26/ci/.github/workflows/run-script.yaml@main
-    needs:
-      - doc
-      - lint
-      - test
-      - validate
     permissions:
       contents: read
     with:

--- a/hack/builder/Dockerfile
+++ b/hack/builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/library/rust:1.94.1
+FROM docker.io/library/rust:1.95.0
 
 LABEL   org.opencontainers.image.authors="heathcliff@heathcliff.eu" \
         org.opencontainers.image.description="Builder and CI image for rust projects. Can be used to cross-compile." \
@@ -7,7 +7,7 @@ LABEL   org.opencontainers.image.authors="heathcliff@heathcliff.eu" \
         org.opencontainers.image.title="rust-qt-builder"
 
 # renovate: datasource=github-releases depName=goreleaser/goreleaser extractVersion=^(?<version>.*)$
-ARG GORELEASER_VERSION=v2.15.2
+ARG GORELEASER_VERSION=v2.15.4
 
 COPY install-deps.sh .
 RUN ./install-deps.sh

--- a/hack/builder/install-deps.sh
+++ b/hack/builder/install-deps.sh
@@ -2,24 +2,11 @@
 
 set -ex
 
-arches="amd64 arm64"
-
-case "$(uname -m)" in
-    x86_64|amd64)
-        current_arch="amd64"
-        ;;
-    aarch64|arm64)
-        current_arch="arm64"
-        ;;
-    *)
-        current_arch="$(uname -m)"
-esac
+arches="arm64"
 
 for arch in ${arches}; do
-    if [ "${arch}" != "${current_arch}" ]; then
-        echo "Adding architecture ${arch}"
-        dpkg --add-architecture "${arch}"
-    fi
+    echo "Adding architecture ${arch}"
+    dpkg --add-architecture "${arch}"
 done
 
 echo "Updating package lists"
@@ -27,36 +14,26 @@ apt-get update
 
 echo "Installing native dependencies"
 apt-get install -y --no-install-recommends --no-install-suggests \
-        build-essential \
-        pkg-config \
-        cmake \
         appstream \
         qt6-base-dev \
         qt6-wayland-dev \
         libfontconfig-dev \
         libxkbcommon-dev
 
+echo "Adding rust target for architecture x86_64"
+rustup target add "x86_64-unknown-linux-gnu"
+
 for arch in ${arches}; do
     case "${arch}" in
-        amd64)
-            pkg_arch="x86-64"
-            rust_target="x86_64-unknown-linux-gnu"
-            ;;
         arm64)
             pkg_arch="aarch64"
-            rust_target="aarch64-unknown-linux-gnu"
             ;;
         *)
             pkg_arch="${arch}"
-            rust_target="${arch}-unknown-linux-gnu"
     esac
 
     echo "Adding rust target for architecture ${arch}"
-    rustup target add "${rust_target}"
-
-    if [ "${arch}" == "${current_arch}" ]; then
-        continue
-    fi
+    rustup target add "${pkg_arch}-unknown-linux-gnu"
 
     echo "Installing dependencies for architecture ${arch}"
     apt-get install -y --no-install-recommends --no-install-suggests \
@@ -75,11 +52,7 @@ echo "Installing rustfmt"
 rustup component add rustfmt
 
 echo "Installing goreleaser"
-arch=$(uname -m)
-if [ "${arch}" == "aarch64" ]; then
-    arch="arm64"
-fi
-curl -SL -o goreleaser.tar.gz "https://github.com/goreleaser/goreleaser/releases/download/${GORELEASER_VERSION}/goreleaser_Linux_${arch}.tar.gz"
+curl -SL -o goreleaser.tar.gz "https://github.com/goreleaser/goreleaser/releases/download/${GORELEASER_VERSION}/goreleaser_Linux_x86_64.tar.gz"
 tar -xzf goreleaser.tar.gz -C "/usr/local/bin" goreleaser
 rm goreleaser.tar.gz
 goreleaser --version


### PR DESCRIPTION
Since the workflow is cross-compiling from amd64 to arm64, it makes no sense to maintain a dual architecture build. Instead only create amd64 builder image.