### PR TITLE
CI: Fix release workflow using old artifact name

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,7 +54,7 @@ jobs:
       update: ${{ inputs.update }}
       tag: ${{ needs.extract-version.outputs.version }}
       release-artifacts: "release/*"
-      artifacts: "turbo-clicker-*"
+      artifacts: "turbo-clicker"
       prerelease: ${{ inputs.prerelease }}
     secrets: inherit
 


### PR DESCRIPTION
Use new artifact name.
Fixes release job failing.