### PR TITLE
Start app mimized to tray

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1875,6 +1875,7 @@ version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e407dc2bd5385dcbdd9c1cf927213d2e4bacda667545abf8839c60f8290f754"
 dependencies = [
+ "async-channel",
  "auto_enums",
  "bitflags 2.11.1",
  "cfg-if",
@@ -1887,6 +1888,7 @@ dependencies = [
  "i-slint-core-macros",
  "icu_normalizer",
  "image",
+ "ksni",
  "lyon_algorithms",
  "lyon_extra",
  "lyon_geom",
@@ -2406,6 +2408,24 @@ name = "khronos_api"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
+
+[[package]]
+name = "ksni"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "814b44c24cd2cb236c3b8a41c7f08237b452a8e76ecaa81f1cec40b5b678215b"
+dependencies = [
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "futures-channel",
+ "futures-lite",
+ "futures-util",
+ "pastey",
+ "serde",
+ "task-local",
+ "zbus",
+]
 
 [[package]]
 name = "kurbo"
@@ -3284,6 +3304,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "percent-encoding"
@@ -4435,6 +4461,15 @@ name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
+name = "task-local"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2972044a9e5e448a506a7ff6f0d03b566d8ef4cd6918a58fc59835a0f8666626"
+dependencies = [
+ "pin-project-lite",
+]
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ slint = { version = "1.17.1", default-features = false, features = [
     "accessibility",
     "compat-1-2",
     "backend-qt",
+    "system-tray",
 ] }
 tokio = { version = "1.50.0", features = [
     "macros",

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,10 +53,34 @@ async fn main() -> Result<(), Box<dyn Error>> {
     register_settings_changed(&app, autoclicker_delay);
     register_configure_hotkey(&app, global_hotkey);
 
-    app.run()?;
+    if let Err(e) = run_app_minimized_to_tray(app.as_weak()) {
+        eprintln!("Failed to run app minimized to tray: {e}");
+        app.run()?;
+    }
 
     save_global_state(&app);
 
+    Ok(())
+}
+
+/// Attempt to initialize the tray icon and run the app. Returns an error if the tray icon could not be initialized.
+fn run_app_minimized_to_tray(app: slint::Weak<AppWindow>) -> Result<(), slint::PlatformError> {
+    let tray = TrayIcon::new()?;
+    tray.on_toggle_window(move || {
+        let Some(app) = app.upgrade() else {
+            return;
+        };
+        if app.window().is_visible() {
+            let _ = app.hide();
+        } else {
+            let _ = app.show();
+        }
+    });
+
+    tray.on_quit(|| slint::quit_event_loop().unwrap());
+
+    tray.show()?;
+    slint::run_event_loop()?;
     Ok(())
 }
 

--- a/ui/app-window.slint
+++ b/ui/app-window.slint
@@ -1,8 +1,9 @@
 import { GlobalState } from "global_state.slint";
 import { MainPage, AboutPage, SettingsPage, CounterPage } from "pages/pages.slint";
 import { NavBar } from "nav-bar.slint";
+import { TrayIcon } from "tray.slint";
 
-export { GlobalState }
+export { GlobalState, TrayIcon }
 
 export component AppWindow inherits Window {
     title: "Turbo Clicker";

--- a/ui/tray.slint
+++ b/ui/tray.slint
@@ -1,0 +1,18 @@
+export component TrayIcon inherits SystemTrayIcon {
+    tooltip: "Turbo Clicker";
+    icon: @image-url("../packages/io.github.heathcliff26.turbo-clicker.svg");
+
+    callback toggle-window;
+    callback quit;
+
+    clicked => {
+        toggle-window();
+    }
+
+    Menu {
+        MenuItem {
+            title: "Quit";
+            activated => { quit(); }
+        }
+    }
+}


### PR DESCRIPTION
To improve usability start the app mimized to tray by default.
This allows to use it as a background app.