### PR TITLE
rpm: Install appindicator deps when needed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,15 @@ validate-metainfo:
 install-deps:
 	hack/install-deps.sh
 
+# Build rpm with code in current workdir using packit
+packit:
+	packit build locally
+
+# Build rpm of upstream code using packit + mock
+packit-mock:
+	packit build in-mock --resultdir tmp
+	rm *.src.rpm
+
 # Clean up generated files
 clean:
 	hack/clean.sh
@@ -63,6 +72,8 @@ help:
 	validate \
 	validate-metainfo \
 	install-deps \
+	packit \
+	packit-mock \
 	clean \
 	help \
 	$(NULL)

--- a/README.md
+++ b/README.md
@@ -27,8 +27,6 @@ The user needs to accept remote access permissions for the app.
 
 ## Installation
 
-**Note:** On GNOME there is no native System Tray support, as such you need to install an extension like [AppIndicator and KStatusNotifierItem Support](https://extensions.gnome.org/extension/615/appindicator-support/).
-
 ### Fedora Copr
 
 The app is available as an rpm by using the fedora copr repository [heathcliff26/turbo-clicker](https://copr.fedorainfracloud.org/coprs/heathcliff26/turbo-clicker/).
@@ -50,6 +48,9 @@ sudo dnf install turbo-clicker
 ```bash
 ./install.sh -i
 ```
+
+**Note:** On GNOME there is no native System Tray support, so you need to install an extension
+like [AppIndicator and KStatusNotifierItem Support](https://extensions.gnome.org/extension/615/appindicator-support/).
 
 #### Uninstalling
 

--- a/tools/copr.spec
+++ b/tools/copr.spec
@@ -16,6 +16,7 @@ URL:            https://github.com/heathcliff26/turbo-clicker
 Source:         %{url}/archive/refs/tags/v%{version}.tar.gz
 
 Requires: polkit
+Recommends: (gnome-shell-extension-appindicator if gnome-shell)
 
 BuildRequires: cargo >= 1.87
 BuildRequires: qt6-qtbase-devel qt6-qtwayland-devel fontconfig-devel


### PR DESCRIPTION
When using GNOME, automatically install and enable appindicator extension. This ensures that the app can run without issues.

Signed-off-by: Heathcliff <heathcliff@heathcliff.eu>